### PR TITLE
Deduplicate table model data to improve UX consistency

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -303,7 +303,10 @@ function App() {
         setActiveCell((old) => ({ ...old, rowIndex: 0 }))
     }, [])
 
-    const resetData = () => setData([{}])
+    const resetData = () => {
+        setData([{}])
+        setDefaultRowValue({})
+    }
 
     return (
         <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,6 @@ function App() {
         const api: GridApi = gridRef?.current?.api
         const data = readLocalStorageValue({ key: CSV_DATA_STORAGE_KEY })
         if (data) {
-            console.log("setting updated data")
             api?.setGridOption("rowData", data)
         }
         const metadata = readLocalStorageValue({ key: METADATA_STORAGE_KEY })
@@ -207,7 +206,6 @@ function App() {
     const addNewRow = () => {
         const api: GridApi = gridRef?.current?.api
         if (!api) {
-            console.log("addNewRow failed")
             return
         }
         api.applyTransaction({ add: [{ ...defaultRowValue }] })
@@ -219,7 +217,6 @@ function App() {
             return
         }
         const currentCell = api.getRowNode(activeCell.rowIndex.toString())
-        console.log(currentCell)
         const currentCellValue = currentCell?.data[activeCell.colId]
 
         return (
@@ -244,7 +241,6 @@ function App() {
     // and auto-index-offset will fail
     const pasteRow = (row) => {
         const dataToInject = copiedRow
-        console.log(dataToInject)
         if (!dataToInject) {
             return
         }
@@ -289,7 +285,6 @@ function App() {
         const baseIndex = getFirstTemplateValue(currentTemplate)?.index
         // const baseIndex = values[0]?.[0]?.index
         const offset = value - baseIndex
-        console.log(baseIndex, offset)
         const newTemplateValue: Record<string, object> = {}
         for (const [key, value] of Object.entries(currentTemplate)) {
             const newValue = value.map((v) => {

--- a/src/CSVTable.tsx
+++ b/src/CSVTable.tsx
@@ -307,6 +307,7 @@ export const CSVGrid = forwardRef(
                     ref={ref}
                     animateRows={false}
                     onRowSelected={onRowSelected}
+                    suppressScrollOnNewData
                     rowSelection={{ mode: "singleRow" }}
                     defaultColDef={{
                         cellRendererParams: {

--- a/src/ResizeableAffix.tsx
+++ b/src/ResizeableAffix.tsx
@@ -77,7 +77,7 @@ export const ResizableAffix = ({ children }) => {
                     ref={resizeRef}
                     style={{
                         width: dimensionProps.width - 10,
-                        height: dimensionProps.height - 10 - 220,
+                        height: dimensionProps.height - 10 - 250,
                     }}
                 >
                     {children}


### PR DESCRIPTION
* Previously, `App.tsx` had local state duplicating the table data model and passing that in via props. This was functional, but caused a lot of excessive rerenders, performance issues, and inconsistent UX experiences.
* All interactions involving table data are now routed through the `GridApi` object places on the `AGGrid` `ref`.